### PR TITLE
Add teacher-only admin mode for activity registration

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -5,7 +5,8 @@ A super simple FastAPI application that allows students to view and sign up for 
 ## Features
 
 - View all available extracurricular activities
-- Sign up for activities
+- Teacher login/logout for protected actions
+- Sign up and unregister students for activities (teacher-only)
 
 ## Getting Started
 
@@ -30,7 +31,20 @@ A super simple FastAPI application that allows students to view and sign up for 
 | Method | Endpoint                                                          | Description                                                         |
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
 | GET    | `/activities`                                                     | Get all activities with their details and current participant count |
-| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| POST   | `/auth/login`                                                     | Teacher login and receive auth token                                |
+| POST   | `/auth/logout`                                                    | Teacher logout                                                      |
+| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up a student for an activity (teacher token required)          |
+| DELETE | `/activities/{activity_name}/unregister?email=student@mergington.edu` | Unregister a student from an activity (teacher token required)   |
+
+### Authentication for protected endpoints
+
+For signup and unregister endpoints, pass the teacher token in header:
+
+```
+X-Teacher-Token: <token>
+```
+
+Teacher credentials are stored in `teachers.json`.
 
 ## Data Model
 

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -10,6 +10,14 @@
     <header>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
+      <div id="teacher-controls" aria-label="Teacher account controls">
+        <button id="user-icon-btn" type="button" title="Teacher account">👤</button>
+        <div id="teacher-menu" class="hidden">
+          <button id="show-login-btn" type="button">Teacher Login</button>
+          <button id="logout-btn" type="button" class="hidden">Logout</button>
+          <p id="teacher-status" class="status-text">Student mode</p>
+        </div>
+      </div>
     </header>
 
     <main>
@@ -23,6 +31,9 @@
 
       <section id="signup-container">
         <h3>Sign Up for an Activity</h3>
+        <p id="teacher-required-message" class="info hidden">
+          Teacher login is required to register or unregister students.
+        </p>
         <form id="signup-form">
           <div class="form-group">
             <label for="email">Student Email:</label>
@@ -40,6 +51,24 @@
         <div id="message" class="hidden"></div>
       </section>
     </main>
+
+    <div id="login-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="login-title">
+      <div class="modal-content">
+        <h3 id="login-title">Teacher Login</h3>
+        <div class="form-group">
+          <label for="teacher-username">Username:</label>
+          <input type="text" id="teacher-username" placeholder="teacher username" />
+        </div>
+        <div class="form-group">
+          <label for="teacher-password">Password:</label>
+          <input type="password" id="teacher-password" placeholder="password" />
+        </div>
+        <div class="modal-actions">
+          <button id="login-submit-btn" type="button">Login</button>
+          <button id="login-cancel-btn" type="button">Cancel</button>
+        </div>
+      </div>
+    </div>
 
     <footer>
       <p>&copy; 2023 Mergington High School</p>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -16,6 +16,7 @@ body {
 }
 
 header {
+  position: relative;
   text-align: center;
   padding: 20px 0;
   margin-bottom: 30px;
@@ -26,6 +27,45 @@ header {
 
 header h1 {
   margin-bottom: 10px;
+}
+
+#teacher-controls {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+}
+
+#user-icon-btn {
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  font-size: 20px;
+  padding: 0;
+  background-color: #ffffff;
+  color: #1a237e;
+}
+
+#teacher-menu {
+  position: absolute;
+  right: 0;
+  top: 46px;
+  width: 180px;
+  background: #fff;
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  padding: 10px;
+  z-index: 10;
+}
+
+#teacher-menu button {
+  width: 100%;
+  margin-bottom: 8px;
+}
+
+#teacher-menu .status-text {
+  margin: 0;
+  font-size: 14px;
+  color: #333;
 }
 
 main {
@@ -190,6 +230,36 @@ button:hover {
 
 .hidden {
   display: none;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 100;
+}
+
+.modal.hidden {
+  display: none;
+}
+
+.modal-content {
+  width: min(420px, 90vw);
+  background: #fff;
+  border-radius: 8px;
+  padding: 20px;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 10px;
+}
+
+.modal-actions button {
+  flex: 1;
 }
 
 footer {

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,12 @@
+{
+  "teachers": [
+    {
+      "username": "teacher1",
+      "password": "mergington123"
+    },
+    {
+      "username": "coach.smith",
+      "password": "soccer2026"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add teacher authentication with JSON-backed credentials
- enforce teacher-only signup/unregister actions
- add top-right user icon with login/logout UI
- document new auth endpoints and header usage

## Changes
- backend auth endpoints: `/auth/login`, `/auth/logout`
- protected activity operations using `X-Teacher-Token`
- new `src/teachers.json` for teacher credentials
- frontend login modal and teacher status controls

## Validation
- static error checks passed on changed files
- existing activities listing remains visible to students